### PR TITLE
회원 서비스 API 및 엔티티 개발 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // swagger
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.3.0'
+
     // Jwt
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/src/main/java/com/qring/auth/application/v1/res/AuthPostResDTOv1.java
+++ b/src/main/java/com/qring/auth/application/v1/res/AuthPostResDTOv1.java
@@ -1,6 +1,5 @@
 package com.qring.auth.application.v1.res;
 
-import com.qring.auth.domain.model.UserEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,9 +13,9 @@ public class AuthPostResDTOv1 {
 
     private User user;
 
-    private static AuthPostResDTOv1 of(UserEntity userEntity) {
+    public static AuthPostResDTOv1 of(String username, String role, String slackEmail) {
         return AuthPostResDTOv1.builder()
-                .user(User.from(userEntity))
+                .user(User.from(username, role, slackEmail))
                 .build();
     }
 
@@ -30,11 +29,11 @@ public class AuthPostResDTOv1 {
         private String role;
         private String slackEmail;
 
-        public static User from(UserEntity userEntity) {
+        public static User from(String username, String role, String slackEmail) {
             return User.builder()
-                    .username(userEntity.getUsername())
-                    .role(userEntity.getRole().getAuthority())
-                    .slackEmail(userEntity.getSlackEmail())
+                    .username(username)
+                    .role(role)
+                    .slackEmail(slackEmail)
                     .build();
         }
     }

--- a/src/main/java/com/qring/auth/application/v1/res/AuthPostResDTOv1.java
+++ b/src/main/java/com/qring/auth/application/v1/res/AuthPostResDTOv1.java
@@ -1,0 +1,41 @@
+package com.qring.auth.application.v1.res;
+
+import com.qring.auth.domain.model.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthPostResDTOv1 {
+
+    private User user;
+
+    private static AuthPostResDTOv1 of(UserEntity userEntity) {
+        return AuthPostResDTOv1.builder()
+                .user(User.from(userEntity))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class User {
+
+        private String username;
+        private String role;
+        private String slackEmail;
+
+        public static User from(UserEntity userEntity) {
+            return User.builder()
+                    .username(userEntity.getUsername())
+                    .role(userEntity.getRole().getAuthority())
+                    .slackEmail(userEntity.getSlackEmail())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/qring/auth/application/v1/res/ResDTO.java
+++ b/src/main/java/com/qring/auth/application/v1/res/ResDTO.java
@@ -1,0 +1,16 @@
+package com.qring.auth.application.v1.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResDTO<T> {
+    private Integer code;
+    private String message;
+    private T data;
+}

--- a/src/main/java/com/qring/auth/domain/model/UserEntity.java
+++ b/src/main/java/com/qring/auth/domain/model/UserEntity.java
@@ -1,0 +1,59 @@
+package com.qring.auth.domain.model;
+
+import com.qring.auth.domain.model.constraint.RoleType;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_user")
+public class UserEntity {
+
+    @Id @Tsid
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true)
+    private String username;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    @Column(name = "role", nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private RoleType role;
+
+    @Column(name = "slack_email", nullable = false)
+    private String slackEmail;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "modified_at" , nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "created_by", updatable = false)
+    private String createdBy;
+
+    @Column(name = "modified_by")
+    private String modifiedBy;
+
+    @Column(name = "deleted_by")
+    private String deletedBy;
+}

--- a/src/main/java/com/qring/auth/domain/model/constraint/RoleType.java
+++ b/src/main/java/com/qring/auth/domain/model/constraint/RoleType.java
@@ -1,0 +1,21 @@
+package com.qring.auth.domain.model.constraint;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RoleType {
+    USER(Authority.CUSTOMER), // 사용자 권한
+    OWNER(Authority.OWNER), // 사장 권한
+    ADMIN(Authority.ADMIN); // 관리자 권한
+
+    private final String authority;
+
+    public static class Authority {
+        public static final String CUSTOMER = "ROLE_CUSTOMER";
+        public static final String OWNER = "ROLE_OWNER";
+        public static final String ADMIN = "ROLE_ADMIN";
+    }
+}
+

--- a/src/main/java/com/qring/auth/infrastructure/docs/AuthControllerSwagger.java
+++ b/src/main/java/com/qring/auth/infrastructure/docs/AuthControllerSwagger.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "Auth", description = "회원가입, 수정, 삭제 관련 사용자 API")
 public interface AuthControllerSwagger {
 
-    @Operation(summary = "회원 생성", description = "사용자 ID를 통해 허브를 생성하는 API 입니다.")
+    @Operation(summary = "회원 생성", description = "사용자의 계정, 비밀번호, 권한, 슬랙 이메일을 통해 회원가입을 하는 API 입니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
             @ApiResponse(responseCode = "400", description = "회원가입 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))

--- a/src/main/java/com/qring/auth/infrastructure/docs/AuthControllerSwagger.java
+++ b/src/main/java/com/qring/auth/infrastructure/docs/AuthControllerSwagger.java
@@ -1,0 +1,26 @@
+package com.qring.auth.infrastructure.docs;
+
+import com.qring.auth.application.v1.res.AuthPostResDTOv1;
+import com.qring.auth.application.v1.res.ResDTO;
+import com.qring.auth.presentation.v1.req.PostAuthReqDTOv1;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Auth", description = "회원가입, 수정, 삭제 관련 사용자 API")
+public interface AuthControllerSwagger {
+
+    @Operation(summary = "회원 생성", description = "사용자 ID를 통해 허브를 생성하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "회원가입 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
+    })
+    @PostMapping("/v1/auth")
+    ResponseEntity<ResDTO<AuthPostResDTOv1>> joinBy(@RequestBody PostAuthReqDTOv1 dto);
+}

--- a/src/main/java/com/qring/auth/presentation/v1/controller/AuthController.java
+++ b/src/main/java/com/qring/auth/presentation/v1/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.qring.auth.presentation.v1.controller;
+
+import com.qring.auth.application.v1.res.AuthPostResDTOv1;
+import com.qring.auth.application.v1.res.ResDTO;
+import com.qring.auth.presentation.v1.req.PostAuthReqDTOv1;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @PostMapping("/v1/auth")
+    public ResponseEntity<ResDTO<AuthPostResDTOv1>> joinBy(PostAuthReqDTOv1 dto) {
+
+        return new ResponseEntity<>(
+                ResDTO.<AuthPostResDTOv1>builder()
+                        .code(HttpStatus.OK.value())
+                        .message("회원가입에 성공했습니다.")
+                        .data(AuthPostResDTOv1.of("tempUser", "tempRole", "temp0000@slack.com"))
+                        .build(),
+                HttpStatus.OK
+        );
+    }
+}

--- a/src/main/java/com/qring/auth/presentation/v1/controller/AuthController.java
+++ b/src/main/java/com/qring/auth/presentation/v1/controller/AuthController.java
@@ -18,11 +18,11 @@ public class AuthController implements AuthControllerSwagger {
 
         return new ResponseEntity<>(
                 ResDTO.<AuthPostResDTOv1>builder()
-                        .code(HttpStatus.OK.value())
+                        .code(HttpStatus.CREATED.value())
                         .message("회원가입에 성공했습니다.")
                         .data(AuthPostResDTOv1.of("tempUser", "tempRole", "temp0000@slack.com"))
                         .build(),
-                HttpStatus.OK
+                HttpStatus.CREATED
         );
     }
 }

--- a/src/main/java/com/qring/auth/presentation/v1/controller/AuthController.java
+++ b/src/main/java/com/qring/auth/presentation/v1/controller/AuthController.java
@@ -2,17 +2,19 @@ package com.qring.auth.presentation.v1.controller;
 
 import com.qring.auth.application.v1.res.AuthPostResDTOv1;
 import com.qring.auth.application.v1.res.ResDTO;
+import com.qring.auth.infrastructure.docs.AuthControllerSwagger;
 import com.qring.auth.presentation.v1.req.PostAuthReqDTOv1;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class AuthController {
+public class AuthController implements AuthControllerSwagger {
 
     @PostMapping("/v1/auth")
-    public ResponseEntity<ResDTO<AuthPostResDTOv1>> joinBy(PostAuthReqDTOv1 dto) {
+    public ResponseEntity<ResDTO<AuthPostResDTOv1>> joinBy(@RequestBody PostAuthReqDTOv1 dto) {
 
         return new ResponseEntity<>(
                 ResDTO.<AuthPostResDTOv1>builder()

--- a/src/main/java/com/qring/auth/presentation/v1/controller/AuthControllerV1.java
+++ b/src/main/java/com/qring/auth/presentation/v1/controller/AuthControllerV1.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class AuthController implements AuthControllerSwagger {
+public class AuthControllerV1 implements AuthControllerSwagger {
 
     @PostMapping("/v1/auth")
     public ResponseEntity<ResDTO<AuthPostResDTOv1>> joinBy(@RequestBody PostAuthReqDTOv1 dto) {

--- a/src/main/java/com/qring/auth/presentation/v1/req/PostAuthReqDTOv1.java
+++ b/src/main/java/com/qring/auth/presentation/v1/req/PostAuthReqDTOv1.java
@@ -1,0 +1,35 @@
+package com.qring.auth.presentation.v1.req;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostAuthReqDTOv1 {
+
+    @Valid
+    @NotNull(message = "회원 정보를 입력해주세요.")
+    private User user;
+
+    @Getter
+    public static class User {
+
+        @NotBlank(message = "아이디를 입력해주세요.")
+        private String username;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,16}$",
+                message = "비밀번호는 8~16자리수여야 합니다. 영문 대소문자, 숫자, 특수문자를 1개 이상 포함해야 합니다.")
+        private String password;
+
+        @NotBlank(message = "권한을 입력해주세요.")
+        private String role;
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        private String slackEmail;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #1 

## 📝 Description

- 회원 서비스의 기본 엔티티를 개발하였습니다.
- 회원 서비스의 회원가입 API 를 개발하였습니다.
- 회원가입 API 를 `Swagger` 를 통해 문서화하였습니다.

### 회원가입 API
```java
    @PostMapping("/v1/auth")
    public ResponseEntity<ResDTO<AuthPostResDTOv1>> joinBy(@RequestBody PostAuthReqDTOv1 dto) {

        return new ResponseEntity<>(
                ResDTO.<AuthPostResDTOv1>builder()
                        .code(HttpStatus.CREATED.value())
                        .message("회원가입에 성공했습니다.")
                        .data(AuthPostResDTOv1.of("tempUser", "tempRole", "temp0000@slack.com"))
                        .build(),
                HttpStatus.CREATED
        );
    }
```
임시적으로 회원가입 간 더미데이터를 반환하도록 구현하였습니다.

### 요청 양식
```java
{
  "user": {
    "username": "string",
    "password": "ZELwvGR!r6yMTpyl",
    "role": "string",
    "slackEmail": "string"
  }
}
```

### 응답 양식
```java
{
  "code": 200,
  "message": "회원가입에 성공했습니다.",
  "data": {
    "user": {
      "username": "tempUser",
      "role": "tempRole",
      "slackEmail": "temp0000@slack.com"
    }
  }
}
```

## 💬 To Reivewers

- 궁금한 점이 있다면 코멘트 남겨주십시오.
