### PR TITLE
Passport 발급 API 구현

### DIFF
--- a/src/main/java/com/qring/auth/application/v1/service/AuthServiceV1.java
+++ b/src/main/java/com/qring/auth/application/v1/service/AuthServiceV1.java
@@ -1,6 +1,7 @@
 package com.qring.auth.application.v1.service;
 
 import com.qring.auth.application.global.exception.BadRequestException;
+import com.qring.auth.application.global.exception.EntityNotFoundException;
 import com.qring.auth.domain.model.UserEntity;
 import com.qring.auth.domain.repository.UserRepository;
 import com.qring.auth.infrastructure.jwt.JwtUtil;
@@ -24,11 +25,27 @@ public class AuthServiceV1 {
 
         validatePasswordMatches(dto, userEntityForCheck);
 
-        return JwtUtil.createToken(
-                userEntityForCheck.getId(),
-                userEntityForCheck.getUsername(),
-                userEntityForCheck.getRole()
+        return JwtUtil.createToken(userEntityForCheck.getId());
+    }
+
+    @Transactional
+    public String postBy(Long userId) {
+
+        UserEntity userEntityForTokenGeneration = getUserEntityById(userId);
+
+        return JwtUtil.createPassport(
+                userEntityForTokenGeneration.getId(),
+                userEntityForTokenGeneration.getUsername(),
+                userEntityForTokenGeneration.getRole().getAuthority(),
+                userEntityForTokenGeneration.getSlackEmail()
         );
+    }
+
+    // -----
+    // NOTE : ID 기준 객체 조회
+    private UserEntity getUserEntityById(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 유저를 찾을 수 없습니다."));
     }
 
     // -----

--- a/src/main/java/com/qring/auth/domain/repository/UserRepository.java
+++ b/src/main/java/com/qring/auth/domain/repository/UserRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public interface UserRepository {
 
+    Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
+
     Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username);
 
     boolean existsByUsernameAndDeletedAtIsNull(String username);

--- a/src/main/java/com/qring/auth/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/qring/auth/infrastructure/jwt/JwtUtil.java
@@ -17,8 +17,6 @@ import java.util.Date;
 public class JwtUtil {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
-    public static final String AUTHORIZATION_KEY = "auth";
-    public static final String USER_IDENTIFIER_KEY = "userId";
     public static final String BEARER_PREFIX = "Bearer ";
     private static final long TOKEN_TIME = 60 * 60 * 1000L;
 
@@ -34,15 +32,28 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public static String createToken(Long userId, String username, RoleType role) {
+    public static String createToken(Long userId) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .claim("userId", userId)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    public static String createPassport(Long id, String username, String role, String slackEmail) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
                         .setSubject(username)
-                        .claim(USER_IDENTIFIER_KEY, userId)
-                        .claim(AUTHORIZATION_KEY, role)
-                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .claim("userId", id)
+                        .claim("role", role)
+                        .claim("slackEmail", slackEmail)
+                        .setExpiration(new Date(date.getTime() + (60 * 60 * 5)))
                         .setIssuedAt(date)
                         .signWith(key, signatureAlgorithm)
                         .compact();

--- a/src/main/java/com/qring/auth/infrastructure/repository/JpaUserRepository.java
+++ b/src/main/java/com/qring/auth/infrastructure/repository/JpaUserRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 
 public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
 
+    Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
+
     Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username);
 
     boolean existsByUsernameAndDeletedAtIsNull(String username);

--- a/src/main/java/com/qring/auth/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/qring/auth/infrastructure/repository/UserRepositoryImpl.java
@@ -13,6 +13,10 @@ public class UserRepositoryImpl implements UserRepository {
 
     private final JpaUserRepository jpaUserRepository;
 
+    public Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id) {
+        return jpaUserRepository.findByIdAndDeletedAtIsNull(id);
+    }
+
     public Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username) {
         return jpaUserRepository.findByUsernameAndDeletedAtIsNull(username);
     }

--- a/src/main/java/com/qring/auth/presentation/v1/controller/AuthControllerV1.java
+++ b/src/main/java/com/qring/auth/presentation/v1/controller/AuthControllerV1.java
@@ -32,4 +32,11 @@ public class AuthControllerV1 implements AuthControllerSwagger {
                 HttpStatus.OK
         );
     }
+
+    // --
+    // XXX : 이거는 External 패키지로 빼서 관리를 해야할까, 클라이언트 컨트롤러에 위치해야 할까 ?
+    @PostMapping("/passport")
+    public ResponseEntity<String> postBy(@RequestHeader("X-User-Id") Long userId) {
+        return ResponseEntity.ok(authServiceV1.postBy(userId));
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #5 

## 📝 Description

- `Passport` 발급 서비스 로직을 구현하였습니다.
- `Passport` 에는 `username`, `userId`, `role`, `slackEmail` 과 같은 유저의 정보가 담겨있습니다.
- 암호화를 통해 안전하게 정보를 전달합니다.
- 짧은 TTL 을 가집니다 (5분)

### 활용법 (ex. Restaurant 서비스)

```java
    @PostMapping
    public ResponseEntity<ResDTO<RestaurantPostResDTOV1>> postBy(@RequestHeader("X-Passport-Token") String token, @Valid @RequestBody PostRestaurantReqDTOV1 dto)
```

- 위 API에 도달하기 전에 `Gateway` 에서 JWT 토큰을 검증한 후, `Passport` 토큰을 발급합니다.
- 이후 발급된 `Passport` 토큰을 헤더의 `X-Passport-Token` 에 담아 전달합니다.

```java
@Component
public class PassportUtil {

    @Value("${service.jwt.secret-key}")
    private String secretKey;

    private static Key key;

    @PostConstruct
    public void init() {
        byte[] bytes = Base64.getDecoder().decode(secretKey);
        key = Keys.hmacShaKeyFor(bytes);
    }

    public static Claims extractClaims(String token) {
        return Jwts.parserBuilder()
                .setSigningKey(key)
                .build()
                .parseClaimsJws(removeBearerPrefix(token))
                .getBody();
    }

    private static String removeBearerPrefix(String token) {
        if (StringUtils.hasText(token) && token.startsWith("Bearer")) {
            return token.substring(7);
        }
        return token;
    }

    public static Long getUserId(String token) {
        return extractClaims(token).get("userId", Long.class);
    }

    public static String getUsername(String token) {
        return extractClaims(token).getSubject();
    }

    public static String getRole(String token) {
        return extractClaims(token).get("role", String.class);
    }

    public static String getSlackEmail(String token) {
        return extractClaims(token).get("slackEmail", String.class);
    }
}
```

- `Passport` 토큰에서 유저의 정보를 추출할 수 있는 `PassportUtil` 클래스를 생성합니다.
- `infrastructure` -> `util` 패키지 아래에서 관리 해주십시오.

```java
service:
  jwt:
    secret-key: ${JWT_SECRET_KEY}

...

JWT_SECRET_KEY: 시크릿키
```

- 각 서비스 yml 파일마다 `Secret Key` 설정을 합니다.

```java
        String username = PassportUtil.getUsername(token);
        String role = PassportUtil.getRole(token);
        Long userId = PassportUtil.getUserId(token);
```

- 위에서 생성한 `Util` 클래스에서 원하는 유저의 정보를 추출 할 수 있습니다.

## 💬 To Reivewers

```java
    @PostMapping("/passport")
    public ResponseEntity<String> postBy(@RequestHeader("X-User-Id") Long userId) {
        return ResponseEntity.ok(authServiceV1.postBy(userId));
    }
```

### 고민 사항: Passport 발급 API 관리 위치

현재 **Passport 발급 API**가 클라이언트와 통신하는 `Controller`에 위치하고 있습니다. 
우리는 외부 통신용 API는 따로 관리하기로 했는데, 이 API도 따로 관리하는 것이 맞는지에 대해 고민 중입니다.

### 고민하는 이유

1. **클라이언트 Controller 에서 관리하자**
   - 해당 API를 호출하는 **Gateway**는 다른 서비스에서 호출하는 것과는 성격이 다르다.
   - 클라이언트가 **Gateway에서 인가 검증**을 거친 후 해당 API를 호출하는 형태이기 때문에, 클라이언트용 `Controller`에서 관리되는 것이 맞다.

2. **외부 통신 Controller 에서 관리하자**
   - 그럼에도 불구하고, 실제로 클라이언트와 **직접 소통하는 것은 아니기** 때문에 **외부 통신용 패키지**에서 관리하는 것이 적합하다.
