### PR TITLE
회원 정보 변경 시 Redis의 Passport 만료 처리 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     // PostgreSQL
     runtimeOnly 'org.postgresql:postgresql'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // TSID
     implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.5'
 

--- a/src/main/java/com/qring/auth/application/v1/message/RedisMessagePublisherV1.java
+++ b/src/main/java/com/qring/auth/application/v1/message/RedisMessagePublisherV1.java
@@ -1,0 +1,7 @@
+package com.qring.auth.application.v1.message;
+
+public interface RedisMessagePublisherV1 {
+
+    void publishUserModificationEvent(Long userId);
+
+}

--- a/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
+++ b/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
@@ -106,7 +106,7 @@ public class UserServiceV1 {
     // -----
     // NOTE : 관리자 권한 검증
     private static void validateUserRole(String passport) {
-        if (!Objects.equals(PassportUtil.getRole(passport), "MASTER")) {
+        if (!Objects.equals(PassportUtil.getRole(passport), "관리자")) {
             throw new UnauthorizedAccessException("접근 권한이 없습니다.");
         }
     }

--- a/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
+++ b/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
@@ -62,7 +62,7 @@ public class UserServiceV1 {
                     dto.getUser().getPhone(),
                     dto.getUser().getRole(),
                     dto.getUser().getSlackEmail(),
-                    "modifiedBy"
+                    PassportUtil.getUsername(passport)
             );
         }
     }

--- a/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
+++ b/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
@@ -78,11 +78,16 @@ public class UserServiceV1 {
     // NOTE : 회원가입 검증 프로세스
     private void validateUserCreationProcess(PostUserReqDTOV1 dto) {
 
-        validateUsernameDuplication(dto.getUser().getUsername());
-
-        validatePhoneDuplication(dto.getUser().getPhone());
-
-        validateSlackEmailDuplication(dto.getUser().getSlackEmail());
+        // NOTE : 필드 중복 검증
+        userRepository.findFirstByUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(
+                dto.getUser().getUsername(),
+                dto.getUser().getPhone(),
+                dto.getUser().getSlackEmail()
+        ).ifPresent(existingUser -> {
+            validateUsernameDuplication(existingUser, dto.getUser().getUsername());
+            validatePhoneDuplication(existingUser, dto.getUser().getPhone());
+            validateSlackEmailDuplication(existingUser, dto.getUser().getSlackEmail());
+        });
 
     }
 
@@ -123,12 +128,6 @@ public class UserServiceV1 {
 
     // -----
     // NOTE : 유저 이름 중복 검증
-    private void validateUsernameDuplication(String username) {
-        if (userRepository.existsByUsernameAndDeletedAtIsNull(username)) {
-            throw new DuplicateResourceException("이미 존재하는 유저이름입니다.");
-        }
-    }
-
     private void validateUsernameDuplication(UserEntity userEntity, String username) {
         if (Objects.equals(userEntity.getUsername(), username)) {
             throw new DuplicateResourceException("이미 존재하는 유저이름입니다.");
@@ -137,12 +136,6 @@ public class UserServiceV1 {
 
     // -----
     // NOTE : 휴대폰 번호 중복 검증
-    private void validatePhoneDuplication(String phone) {
-        if (userRepository.existsByPhoneAndDeletedAtIsNull(phone)) {
-            throw new DuplicateResourceException("이미 등록된 휴대폰 번호입니다.");
-        }
-    }
-
     private void validatePhoneDuplication(UserEntity userEntity, String phone) {
         if (Objects.equals(userEntity.getPhone(), phone)) {
             throw new DuplicateResourceException("이미 등록된 휴대전화 번호입니다.");
@@ -151,12 +144,6 @@ public class UserServiceV1 {
 
     // -----
     // NOTE : 슬랙 이메일 중복 검증
-    private void validateSlackEmailDuplication(String slackEmail) {
-        if (userRepository.existsBySlackEmailAndDeletedAtIsNull(slackEmail)) {
-            throw new DuplicateResourceException("이미 등록된 슬랙 이메일입니다.");
-        }
-    }
-
     private void validateSlackEmailDuplication(UserEntity userEntity, String slackEmail) {
         if (Objects.equals(userEntity.getSlackEmail(), slackEmail)) {
             throw new DuplicateResourceException("이미 등록된 슬랙 이메일입니다.");

--- a/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
+++ b/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
@@ -3,6 +3,7 @@ package com.qring.auth.application.v1.service;
 import com.qring.auth.application.global.exception.DuplicateResourceException;
 import com.qring.auth.application.global.exception.EntityNotFoundException;
 import com.qring.auth.application.global.exception.UnauthorizedAccessException;
+import com.qring.auth.application.v1.message.RedisMessagePublisherV1;
 import com.qring.auth.application.v1.res.UserPostResDTOV1;
 import com.qring.auth.domain.model.UserEntity;
 import com.qring.auth.domain.repository.UserRepository;
@@ -22,6 +23,7 @@ public class UserServiceV1 {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RedisMessagePublisherV1 redisMessagePublisherV1;
 
     @Transactional
     public UserPostResDTOV1 joinBy(PostUserReqDTOV1 dto) {
@@ -65,6 +67,8 @@ public class UserServiceV1 {
                     PassportUtil.getUsername(passport)
             );
         }
+
+        redisMessagePublisherV1.publishUserModificationEvent(userEntityForModify.getId());
     }
 
     // -----

--- a/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
+++ b/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
@@ -1,14 +1,18 @@
 package com.qring.auth.application.v1.service;
 
 import com.qring.auth.application.global.exception.DuplicateResourceException;
+import com.qring.auth.application.global.exception.EntityNotFoundException;
 import com.qring.auth.application.v1.res.UserPostResDTOV1;
 import com.qring.auth.domain.model.UserEntity;
 import com.qring.auth.domain.repository.UserRepository;
 import com.qring.auth.presentation.v1.req.PostUserReqDTOV1;
+import com.qring.auth.presentation.v1.req.PutUserReqDTOV1;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +37,45 @@ public class UserServiceV1 {
         return UserPostResDTOV1.of(userRepository.save(userEntityForSave));
     }
 
+    @Transactional
+    public void putBy(String passport, Long id, PutUserReqDTOV1 dto) {
+
+        // --
+        // TODO : 권한 검증 로직 구현 ( MASTER만 접근 가능 )
+        // --
+
+        validateUserModificationProcess(id, dto);
+
+        UserEntity userEntityForModify = getUserEntityById(id);
+
+        if (!passwordEncoder.matches(dto.getUser().getPassword(), userEntityForModify.getPassword())) {
+            userEntityForModify.modifyUserEntity(
+                    dto.getUser().getUsername(),
+                    passwordEncoder.encode(dto.getUser().getPassword()),
+                    dto.getUser().getPhone(),
+                    dto.getUser().getRole(),
+                    dto.getUser().getSlackEmail(),
+                    "modifiedBy"
+            );
+        } else {
+            userEntityForModify.modifyUserEntity(
+                    dto.getUser().getUsername(),
+                    userEntityForModify.getPassword(),
+                    dto.getUser().getPhone(),
+                    dto.getUser().getRole(),
+                    dto.getUser().getSlackEmail(),
+                    "modifiedBy"
+            );
+        }
+    }
+
+    // -----
+    // NOTE : 유저 조회 메서드
+    private UserEntity getUserEntityById(Long id) {
+        return userRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
+    }
+
     // -----
     // NOTE : 회원가입 검증 프로세스
     private void validateUserCreationProcess(PostUserReqDTOV1 dto) {
@@ -46,10 +89,45 @@ public class UserServiceV1 {
     }
 
     // -----
+    // NOTE : 회원수정 검증 프로세스
+    private void validateUserModificationProcess(Long id, PutUserReqDTOV1 dto) {
+        userRepository.findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(
+                id,
+                dto.getUser().getUsername(),
+                dto.getUser().getPhone(),
+                dto.getUser().getSlackEmail()
+        ).ifPresent(existingUser -> {
+            validateUsernameDuplication(existingUser, dto.getUser().getUsername());
+            validatePhoneDuplication(existingUser, dto.getUser().getPhone());
+            validateSlackEmailDuplication(existingUser, dto.getUser().getSlackEmail());
+        });
+    }
+
+    // -----
+    // NOTE : 유저 이름 중복 검증
+    private void validateUsernameDuplication(String username) {
+        if (userRepository.existsByUsernameAndDeletedAtIsNull(username)) {
+            throw new DuplicateResourceException("이미 존재하는 유저이름입니다.");
+        }
+    }
+
+    private void validateUsernameDuplication(UserEntity userEntity, String username) {
+        if (Objects.equals(userEntity.getUsername(), username)) {
+            throw new DuplicateResourceException("이미 존재하는 유저이름입니다.");
+        }
+    }
+
+    // -----
     // NOTE : 휴대폰 번호 중복 검증
     private void validatePhoneDuplication(String phone) {
         if (userRepository.existsByPhoneAndDeletedAtIsNull(phone)) {
             throw new DuplicateResourceException("이미 등록된 휴대폰 번호입니다.");
+        }
+    }
+
+    private void validatePhoneDuplication(UserEntity userEntity, String phone) {
+        if (Objects.equals(userEntity.getPhone(), phone)) {
+            throw new DuplicateResourceException("이미 등록된 휴대전화 번호입니다.");
         }
     }
 
@@ -61,11 +139,9 @@ public class UserServiceV1 {
         }
     }
 
-    // -----
-    // NOTE : 유저 이름 중복 검증
-    private void validateUsernameDuplication(String username) {
-        if (userRepository.existsByUsernameAndDeletedAtIsNull(username)) {
-            throw new DuplicateResourceException("이미 존재하는 유저이름입니다.");
+    private void validateSlackEmailDuplication(UserEntity userEntity, String slackEmail) {
+        if (Objects.equals(userEntity.getSlackEmail(), slackEmail)) {
+            throw new DuplicateResourceException("이미 등록된 슬랙 이메일입니다.");
         }
     }
 }

--- a/src/main/java/com/qring/auth/domain/model/UserEntity.java
+++ b/src/main/java/com/qring/auth/domain/model/UserEntity.java
@@ -78,4 +78,13 @@ public class UserEntity {
                 .slackEmail(slackEmail)
                 .build();
     }
+
+    public void modifyUserEntity(String username, String password, String phone, String role, String slackEmail, String modifiedBy) {
+        this.username = username;
+        this.password = password;
+        this.phone = phone;
+        this.role = RoleType.fromString(role);
+        this.slackEmail = slackEmail;
+        this.modifiedBy = modifiedBy;
+    }
 }

--- a/src/main/java/com/qring/auth/domain/repository/UserRepository.java
+++ b/src/main/java/com/qring/auth/domain/repository/UserRepository.java
@@ -10,13 +10,9 @@ public interface UserRepository {
 
     Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username);
 
+    Optional<UserEntity> findFirstByUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(String username, String phone, String slackEmail);
+
     Optional<UserEntity> findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(Long id, String username, String phone, String slackEmail);
-
-    boolean existsByUsernameAndDeletedAtIsNull(String username);
-
-    boolean existsByPhoneAndDeletedAtIsNull(String phone);
-
-    boolean existsBySlackEmailAndDeletedAtIsNull(String slackEmail);
 
     UserEntity save(UserEntity userEntity);
 

--- a/src/main/java/com/qring/auth/domain/repository/UserRepository.java
+++ b/src/main/java/com/qring/auth/domain/repository/UserRepository.java
@@ -10,6 +10,8 @@ public interface UserRepository {
 
     Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username);
 
+    Optional<UserEntity> findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(Long id, String username, String phone, String slackEmail);
+
     boolean existsByUsernameAndDeletedAtIsNull(String username);
 
     boolean existsByPhoneAndDeletedAtIsNull(String phone);

--- a/src/main/java/com/qring/auth/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/qring/auth/infrastructure/jwt/JwtUtil.java
@@ -1,11 +1,9 @@
 package com.qring.auth.infrastructure.jwt;
 
-import com.qring.auth.domain.model.constraint.RoleType;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -18,7 +16,6 @@ public class JwtUtil {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
-    private static final long TOKEN_TIME = 60 * 60 * 1000L;
 
     @Value("${service.jwt.secret-key}")
     private String secretKey;
@@ -38,7 +35,7 @@ public class JwtUtil {
         return BEARER_PREFIX +
                 Jwts.builder()
                         .claim("userId", userId)
-                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setExpiration(new Date(date.getTime() + (60 * 60 * 1000L)))
                         .setIssuedAt(date)
                         .signWith(key, signatureAlgorithm)
                         .compact();
@@ -53,7 +50,7 @@ public class JwtUtil {
                         .claim("userId", id)
                         .claim("role", role)
                         .claim("slackEmail", slackEmail)
-                        .setExpiration(new Date(date.getTime() + (60 * 60 * 5)))
+                        .setExpiration(new Date(date.getTime() + (5 * 60 * 1000L)))
                         .setIssuedAt(date)
                         .signWith(key, signatureAlgorithm)
                         .compact();

--- a/src/main/java/com/qring/auth/infrastructure/messaging/redis/RedisMessagePublisherImplV1.java
+++ b/src/main/java/com/qring/auth/infrastructure/messaging/redis/RedisMessagePublisherImplV1.java
@@ -2,11 +2,13 @@ package com.qring.auth.infrastructure.messaging.redis;
 
 import com.qring.auth.application.v1.message.RedisMessagePublisherV1;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j(topic = "RedisMessagePublisherV1 Log")
 public class RedisMessagePublisherImplV1 implements RedisMessagePublisherV1 {
 
     private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
@@ -17,8 +19,8 @@ public class RedisMessagePublisherImplV1 implements RedisMessagePublisherV1 {
         String message = String.valueOf(userId);
 
         reactiveRedisTemplate.convertAndSend(channel, message)
-                .doOnSuccess(result -> System.out.println("Redis 채널로 메시지 발행 성공: " + message))
-                .doOnError(error -> System.err.println("Redis 채널 메시지 발행 실패: " + error.getMessage()))
+                .doOnSuccess(result -> log.info("Redis 채널로 메시지 발행 성공: 채널={}, 메시지={}", channel, message))
+                .doOnError(error -> log.error("Redis 채널 메시지 발행 실패: {}", error.getMessage(), error))
                 .subscribe();
     }
 }

--- a/src/main/java/com/qring/auth/infrastructure/messaging/redis/RedisMessagePublisherImplV1.java
+++ b/src/main/java/com/qring/auth/infrastructure/messaging/redis/RedisMessagePublisherImplV1.java
@@ -1,0 +1,24 @@
+package com.qring.auth.infrastructure.messaging.redis;
+
+import com.qring.auth.application.v1.message.RedisMessagePublisherV1;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisMessagePublisherImplV1 implements RedisMessagePublisherV1 {
+
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+    public void publishUserModificationEvent(Long userId) {
+
+        String channel = "user-modification-channel";
+        String message = String.valueOf(userId);
+
+        reactiveRedisTemplate.convertAndSend(channel, message)
+                .doOnSuccess(result -> System.out.println("Redis 채널로 메시지 발행 성공: " + message))
+                .doOnError(error -> System.err.println("Redis 채널 메시지 발행 실패: " + error.getMessage()))
+                .subscribe();
+    }
+}

--- a/src/main/java/com/qring/auth/infrastructure/repository/JpaUserRepository.java
+++ b/src/main/java/com/qring/auth/infrastructure/repository/JpaUserRepository.java
@@ -12,6 +12,8 @@ public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username);
 
+    Optional<UserEntity> findFirstByUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(String username, String phone, String slackEmail);
+
     @Query("select u " +
             "from UserEntity u " +
             "where u.id <> :id " +
@@ -19,11 +21,5 @@ public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
             "and u.deletedAt is null"
     )
     Optional<UserEntity> findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(Long id, String username, String phone, String slackEmail);
-
-    boolean existsByUsernameAndDeletedAtIsNull(String username);
-
-    boolean existsByPhoneAndDeletedAtIsNull(String phone);
-
-    boolean existsBySlackEmailAndDeletedAtIsNull(String email);
 
 }

--- a/src/main/java/com/qring/auth/infrastructure/repository/JpaUserRepository.java
+++ b/src/main/java/com/qring/auth/infrastructure/repository/JpaUserRepository.java
@@ -2,6 +2,7 @@ package com.qring.auth.infrastructure.repository;
 
 import com.qring.auth.domain.model.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -10,6 +11,14 @@ public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByIdAndDeletedAtIsNull(Long id);
 
     Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username);
+
+    @Query("select u " +
+            "from UserEntity u " +
+            "where u.id <> :id " +
+            "and (u.username = :username or u.phone = :phone or u.slackEmail = :slackEmail) " +
+            "and u.deletedAt is null"
+    )
+    Optional<UserEntity> findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(Long id, String username, String phone, String slackEmail);
 
     boolean existsByUsernameAndDeletedAtIsNull(String username);
 

--- a/src/main/java/com/qring/auth/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/qring/auth/infrastructure/repository/UserRepositoryImpl.java
@@ -22,20 +22,12 @@ public class UserRepositoryImpl implements UserRepository {
         return jpaUserRepository.findByUsernameAndDeletedAtIsNull(username);
     }
 
+    public Optional<UserEntity> findFirstByUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(String username, String phone, String slackEmail) {
+        return jpaUserRepository.findFirstByUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(username, phone, slackEmail);
+    }
+
     public Optional<UserEntity> findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(Long id, String username, String phone, String slackEmail) {
         return jpaUserRepository.findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(id, username, phone, slackEmail);
-    }
-
-    public boolean existsByUsernameAndDeletedAtIsNull(String username) {
-        return jpaUserRepository.existsByUsernameAndDeletedAtIsNull(username);
-    }
-
-    public boolean existsByPhoneAndDeletedAtIsNull(String phone) {
-        return jpaUserRepository.existsByPhoneAndDeletedAtIsNull(phone);
-    }
-
-    public boolean existsBySlackEmailAndDeletedAtIsNull(String slackEmail) {
-        return jpaUserRepository.existsBySlackEmailAndDeletedAtIsNull(slackEmail);
     }
 
     public UserEntity save(UserEntity userEntity) {

--- a/src/main/java/com/qring/auth/infrastructure/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/qring/auth/infrastructure/repository/UserRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.qring.auth.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,6 +20,10 @@ public class UserRepositoryImpl implements UserRepository {
 
     public Optional<UserEntity> findByUsernameAndDeletedAtIsNull(String username) {
         return jpaUserRepository.findByUsernameAndDeletedAtIsNull(username);
+    }
+
+    public Optional<UserEntity> findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(Long id, String username, String phone, String slackEmail) {
+        return jpaUserRepository.findUserByIdNotAndUsernameOrPhoneOrSlackEmailAndDeletedAtIsNull(id, username, phone, slackEmail);
     }
 
     public boolean existsByUsernameAndDeletedAtIsNull(String username) {

--- a/src/main/java/com/qring/auth/infrastructure/util/PassportUtil.java
+++ b/src/main/java/com/qring/auth/infrastructure/util/PassportUtil.java
@@ -1,0 +1,58 @@
+package com.qring.auth.infrastructure.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+
+@Component
+public class PassportUtil {
+
+    @Value("${service.jwt.secret-key}")
+    private String secretKey;
+
+    private static Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public static Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(removeBearerPrefix(token))
+                .getBody();
+    }
+
+    private static String removeBearerPrefix(String token) {
+        if (StringUtils.hasText(token) && token.startsWith("Bearer")) {
+            return token.substring(7);
+        }
+        return token;
+    }
+
+    public static Long getUserId(String token) {
+        return extractClaims(token).get("userId", Long.class);
+    }
+
+    public static String getUsername(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+    public static String getRole(String token) {
+        return extractClaims(token).get("role", String.class);
+    }
+
+    public static String getSlackEmail(String token) {
+        return extractClaims(token).get("slackEmail", String.class);
+    }
+}

--- a/src/main/java/com/qring/auth/presentation/v1/controller/UserControllerV1.java
+++ b/src/main/java/com/qring/auth/presentation/v1/controller/UserControllerV1.java
@@ -5,14 +5,12 @@ import com.qring.auth.application.global.dto.ResDTO;
 import com.qring.auth.application.v1.service.UserServiceV1;
 import com.qring.auth.infrastructure.docs.UserControllerSwagger;
 import com.qring.auth.presentation.v1.req.PostUserReqDTOV1;
+import com.qring.auth.presentation.v1.req.PutUserReqDTOV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +29,22 @@ public class UserControllerV1 implements UserControllerSwagger {
                         .data(userServiceV1.joinBy(dto))
                         .build(),
                 HttpStatus.CREATED
+        );
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResDTO<Object>> putBy(@RequestHeader("X-Passport-Token") String passport,
+                                                @PathVariable Long id,
+                                                @Valid @RequestBody PutUserReqDTOV1 dto) {
+
+        userServiceV1.putBy(passport, id, dto);
+
+        return new ResponseEntity<>(
+                ResDTO.builder()
+                        .code(HttpStatus.OK.value())
+                        .message("회원 수정에 성공했습니다.")
+                        .build(),
+                HttpStatus.OK
         );
     }
 }

--- a/src/main/java/com/qring/auth/presentation/v1/req/PutUserReqDTOV1.java
+++ b/src/main/java/com/qring/auth/presentation/v1/req/PutUserReqDTOV1.java
@@ -1,0 +1,45 @@
+package com.qring.auth.presentation.v1.req;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PutUserReqDTOV1 {
+
+    @Valid
+    @NotNull(message = "회원 정보를 입력해주세요.")
+    private User user;
+
+    @Getter
+    public static class User {
+
+        @NotBlank(message = "아이디를 입력해주세요.")
+        private String username;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*#?&])[A-Za-z\\d$@$!%*#?&]{8,16}$",
+                message = "비밀번호는 8~16자리수여야 합니다. 영문 대소문자, 숫자, 특수문자를 1개 이상 포함해야 합니다.")
+        private String password;
+
+        @NotBlank(message = "휴대전화 번호를 입력해주세요")
+        @Pattern(
+                regexp = "^(010|011|016|017|018|019)(-?\\d{3,4}-?\\d{4})$",
+                message = "휴대전화 번호는 010-1234-5678 또는 01012345678 형식으로 입력해주세요."
+        )
+        private String phone;
+
+        @NotBlank(message = "권한을 입력해주세요.")
+        private String role;
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "유효한 이메일 주소를 입력해주세요.")
+        private String slackEmail;
+
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #7 

## 📝 Description

- 회원정보 수정 시 `Passport` 토큰 만료 기능을 구현했습니다.
- Redis 의 Pub/Sub 기능을 이용하였습니다.

### Passport 발급 후 Redis 에 저장
<img width="319" alt="스크린샷 2025-01-05 오후 7 53 09" src="https://github.com/user-attachments/assets/82c9fa12-7150-492c-808f-2f61fa94e8d8" />

- `userId` 를 `key` 로 가지는 `passport` 가 `redis` 에 존재합니다.


### 회원 정보 수정
```java
    @Transactional
    public void putBy(String passport, Long id, PutUserReqDTOV1 dto) {

        validateUserModificationProcess(passport, id, dto);

        UserEntity userEntityForModify = getUserEntityById(id);

        ( 회원 정보 수정 로직 )

...

        redisMessagePublisherV1.publishUserModificationEvent(userEntityForModify.getId());
    }

```
- 회원정보 수정 후 `userId` 를 메시지에 담아 발행합니다.


### Message Publisher
```java
@Component
@RequiredArgsConstructor
@Slf4j(topic = "RedisMessagePublisherV1 Log")
public class RedisMessagePublisherImplV1 implements RedisMessagePublisherV1 {

    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;

    public void publishUserModificationEvent(Long userId) {

        String channel = "user-modification-channel";
        String message = String.valueOf(userId);

        reactiveRedisTemplate.convertAndSend(channel, message)
                .doOnSuccess(result -> log.info("Redis 채널로 메시지 발행 성공: 채널={}, 메시지={}", channel, message))
                .doOnError(error -> log.error("Redis 채널 메시지 발행 실패: {}", error.getMessage(), error))
                .subscribe();
    }
}
```
```java
2025-01-05T19:56:48.549+09:00  INFO 54350 --- [auth-service] [ioEventLoop-4-1] RedisMessagePublisherV1 Log              : Redis 채널로 메시지 발행 성공: 채널=user-modification-channel, 메시지=662160624610866039
```
- `user-modification-channel` 해당 이름의 채널로 메시지가 발행됩니다.

### Gateway Message Subscriber
```java
@Component
@RequiredArgsConstructor
@Slf4j(topic = "RedisMessageSubscriber Log")
public class RedisMessageSubscriber {

    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;

    @PostConstruct
    public void subscribeToUserUpdates() {
        reactiveRedisTemplate.listenToChannel("user-modification-channel")
                .doOnNext(message -> {
                    String userId = message.getMessage();
                    log.info("회원 정보 업데이트 감지. Redis에서 userId={} 데이터를 만료합니다.", userId);

                    reactiveRedisTemplate.delete(userId)
                            .doOnSuccess(deleted -> log.info("Redis에서 userId={} 데이터 삭제 완료: {}", userId, deleted))
                            .subscribe();
                })
                .subscribe();
    }
}
```
```java
2025-01-05T19:56:48.288+09:00  INFO 54345 --- [gateway-service] [io-19001-exec-3] JwtAuthorizationFilterV2 Log             : JWT 토큰 검증 성공. Redis에서 Passport 확인
2025-01-05T19:56:48.291+09:00  INFO 54345 --- [gateway-service] [ioEventLoop-4-1] JwtAuthorizationFilterV2 Log             : Redis에서 Passport Token 조회 성공: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJleGFtcGxlMiIsInVzZXJJZCI6NjYyMTYwNjI0NjEwODY2MDM5LCJyb2xlIjoi6rSA66as7J6QIiwic2xhY2tFbWFpbCI6InVzZXJAZXhhbXBsZTEuY29tIiwiZXhwIjoxNzM2MDc0NjU4LCJpYXQiOjE3MzYwNzQzNTh9.Ic8Jc7YIumLcOpHNM9vZIy2KG44rZQHTvJMWUxxqNVk
2025-01-05T19:56:48.551+09:00  INFO 54345 --- [gateway-service] [ioEventLoop-4-2] RedisSubscriber Log                      : 회원 정보 업데이트 감지. Redis에서 userId=662160624610866039 데이터를 만료합니다.
2025-01-05T19:56:48.557+09:00  INFO 54345 --- [gateway-service] [ioEventLoop-4-1] RedisSubscriber Log                      : Redis에서 userId=662160624610866039 데이터 삭제 완료: 1
2025-01-05T19:56:48.573+09:00  INFO 54345 --- [gateway-service] [ctor-http-nio-6] Gateway LoggingFilter Log                : Request URI is 200 OK
```
- `user-modification-channel` 채널에 발행된 메시지를 소비합니다.
- 메시지를 소비하면, 해당 `userId` 가 `key` 로 존재하는 값을 `Redis` 에서 제거합니다.
- 이로써, 유저는 다음 인가과정에서 최신화된 `Passport` 를 발급받게 됩니다.


## 💬 To Reivewers
