### PR TITLE
유저 상세조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
+    // Logback
+    implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+
     // Web, Lombok, Valid, Test
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/qring/auth/application/v1/res/UserGetByIdResDTOV1.java
+++ b/src/main/java/com/qring/auth/application/v1/res/UserGetByIdResDTOV1.java
@@ -14,7 +14,7 @@ public class UserGetByIdResDTOV1 {
 
     private User user;
 
-    private static UserGetByIdResDTOV1 of(UserEntity userEntity) {
+    public static UserGetByIdResDTOV1 of(UserEntity userEntity) {
         return UserGetByIdResDTOV1.builder()
                 .user(User.from(userEntity))
                 .build();

--- a/src/main/java/com/qring/auth/application/v1/res/UserGetByIdResDTOV1.java
+++ b/src/main/java/com/qring/auth/application/v1/res/UserGetByIdResDTOV1.java
@@ -1,0 +1,43 @@
+package com.qring.auth.application.v1.res;
+
+import com.qring.auth.domain.model.UserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserGetByIdResDTOV1 {
+
+    private User user;
+
+    private static UserGetByIdResDTOV1 of(UserEntity userEntity) {
+        return UserGetByIdResDTOV1.builder()
+                .user(User.from(userEntity))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class User {
+
+        private Long id;
+        private String username;
+        private String phone;
+        private String slackEmail;
+
+        public static User from(UserEntity userEntity) {
+            return User.builder()
+                    .id(userEntity.getId())
+                    .username(userEntity.getUsername())
+                    .phone(userEntity.getPhone())
+                    .slackEmail(userEntity.getSlackEmail())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
+++ b/src/main/java/com/qring/auth/application/v1/service/UserServiceV1.java
@@ -4,6 +4,7 @@ import com.qring.auth.application.global.exception.DuplicateResourceException;
 import com.qring.auth.application.global.exception.EntityNotFoundException;
 import com.qring.auth.application.global.exception.UnauthorizedAccessException;
 import com.qring.auth.application.v1.message.RedisMessagePublisherV1;
+import com.qring.auth.application.v1.res.UserGetByIdResDTOV1;
 import com.qring.auth.application.v1.res.UserPostResDTOV1;
 import com.qring.auth.domain.model.UserEntity;
 import com.qring.auth.domain.repository.UserRepository;
@@ -39,6 +40,14 @@ public class UserServiceV1 {
         );
 
         return UserPostResDTOV1.of(userRepository.save(userEntityForSave));
+    }
+
+    @Transactional(readOnly = true)
+    public UserGetByIdResDTOV1 getBy(Long id) {
+
+        UserEntity userEntityForMapping = getUserEntityById(id);
+
+        return UserGetByIdResDTOV1.of(userEntityForMapping);
     }
 
     @Transactional

--- a/src/main/java/com/qring/auth/infrastructure/docs/UserControllerSwagger.java
+++ b/src/main/java/com/qring/auth/infrastructure/docs/UserControllerSwagger.java
@@ -1,5 +1,6 @@
 package com.qring.auth.infrastructure.docs;
 
+import com.qring.auth.application.v1.res.UserGetByIdResDTOV1;
 import com.qring.auth.application.v1.res.UserPostResDTOV1;
 import com.qring.auth.application.global.dto.ResDTO;
 import com.qring.auth.presentation.v1.req.PostUserReqDTOV1;
@@ -10,9 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User", description = "회원가입, 수정, 삭제 관련 사용자 API")
 @RequestMapping("/v1/users")
@@ -25,4 +24,13 @@ public interface UserControllerSwagger {
     })
     @PostMapping("/join")
     ResponseEntity<ResDTO<UserPostResDTOV1>> joinBy(@RequestBody PostUserReqDTOV1 dto);
+
+
+    @Operation(summary = "회원 상세조회", description = "회원 상세조회를 하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 상세조회 성공", content = @Content(schema = @Schema(implementation = ResDTO.class))),
+            @ApiResponse(responseCode = "400", description = "회원 상세조회 실패.", content = @Content(schema = @Schema(implementation = ResDTO.class)))
+    })
+    @GetMapping("/{id}")
+    ResponseEntity<ResDTO<UserGetByIdResDTOV1>> getBy(@PathVariable Long id);
 }

--- a/src/main/java/com/qring/auth/presentation/v1/controller/UserControllerV1.java
+++ b/src/main/java/com/qring/auth/presentation/v1/controller/UserControllerV1.java
@@ -1,5 +1,6 @@
 package com.qring.auth.presentation.v1.controller;
 
+import com.qring.auth.application.v1.res.UserGetByIdResDTOV1;
 import com.qring.auth.application.v1.res.UserPostResDTOV1;
 import com.qring.auth.application.global.dto.ResDTO;
 import com.qring.auth.application.v1.service.UserServiceV1;
@@ -29,6 +30,19 @@ public class UserControllerV1 implements UserControllerSwagger {
                         .data(userServiceV1.joinBy(dto))
                         .build(),
                 HttpStatus.CREATED
+        );
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResDTO<UserGetByIdResDTOV1>> getBy(@PathVariable Long id) {
+
+        return new ResponseEntity<>(
+                ResDTO.<UserGetByIdResDTOV1>builder()
+                        .code(HttpStatus.OK.value())
+                        .message("회원 상세조회에 성공했습니다.")
+                        .data(userServiceV1.getBy(id))
+                        .build(),
+                HttpStatus.OK
         );
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #9 

## 📝 Description

- 유저 상세조회 기능을 구현했습니다.
- `path` 를 통해 `id` 를 입력받고, 해당 `id` 의 유저를 조회합니다.

### 응답
```java
{
    "code": 200,
    "message": "회원 상세조회에 성공했습니다.",
    "data": {
        "user": {
            "id": 665128441177441504,
            "username": "admin",
            "phone": "010-1111-1113",
            "slackEmail": "user@temp3.com"
        }
    }
}
```

## 💬 To Reivewers
